### PR TITLE
Several fixes

### DIFF
--- a/src/TypedSvg/Attributes.elm
+++ b/src/TypedSvg/Attributes.elm
@@ -1899,9 +1899,9 @@ strokeMiterlimit =
 
 
 {-| -}
-strokeOpacity : String -> Attribute msg
-strokeOpacity =
-    attribute "stroke-opacity"
+strokeOpacity : Opacity -> Attribute msg
+strokeOpacity opacity =
+    attribute "stroke-opacity" <| opacityToString opacity
 
 
 {-| -}

--- a/src/TypedSvg/TypesToStrings.elm
+++ b/src/TypedSvg/TypesToStrings.elm
@@ -63,7 +63,7 @@ alignToString align =
             "none"
 
         Align x y ->
-            "x" ++ (scaleToString x) ++ "y" ++ (scaleToString y)
+            "x" ++ (scaleToString x) ++ "Y" ++ (scaleToString y)
 
 
 alignmentBaselineToString : AlignmentBaseline -> String
@@ -876,13 +876,13 @@ scaleToString : Scale -> String
 scaleToString scale =
     case scale of
         ScaleMin ->
-            "min"
+            "Min"
 
         ScaleMid ->
-            "mid"
+            "Mid"
 
         ScaleMax ->
-            "max"
+            "Max"
 
 
 shapeRenderingToString : ShapeRendering -> String


### PR DESCRIPTION
* Fix preserveAspectRatio align parameter  (Avoid error in Chrome): It have to be case sensitive. See https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/preserveAspectRatio
* Fix typed strokeOpacity