### PR TITLE
Fix: animateTransformType and contentType now returns correct svg attribute "type".

### DIFF
--- a/src/TypedSvg/Attributes.elm
+++ b/src/TypedSvg/Attributes.elm
@@ -149,7 +149,7 @@ See: <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/type>
 -}
 animateTransformType : AnimateTransformType -> Attribute msg
 animateTransformType transformType =
-    attribute "type_" <| animateTransformTypeToString transformType
+    attribute "type" <| animateTransformTypeToString transformType
 
 
 {-| Values will be applied in order over the course of the animation. If a list
@@ -536,7 +536,7 @@ See: <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/type>
 -}
 contentType : String -> Attribute msg
 contentType t =
-    attribute "type_" t
+    attribute "type" t
 
 
 {-| The `cursor` attribute specifies the mouse cursor displayed when the mouse


### PR DESCRIPTION
A fix for two attribute functions which return attribute name `"type_"` instead of `"type"`. I've made an ellie which demonstrates the issue in the case of transform animations:
https://ellie-app.com/3qdYZ7xQXzqa1

This is my first ever pull request, so don't hesitate to point out mistakes or faux pas. Thanks!

Reproducing the ellie code for posterity:
```
module Main exposing (main)

import TypedSvg as Svg
import TypedSvg.Attributes exposing (..)
import TypedSvg.Attributes.InPx exposing (height, width, x, y)
import TypedSvg.Core exposing (Attribute, Svg, attribute)
import TypedSvg.Types exposing (..)



-- Could not import


animateTransformTypeToString : AnimateTransformType -> String
animateTransformTypeToString animateTransformType =
    case animateTransformType of
        AnimateTransformTypeTranslate ->
            "translate"

        AnimateTransformTypeScale ->
            "scale"

        AnimateTransformTypeRotate ->
            "rotate"

        AnimateTransformTypeSkewX ->
            "skewX"

        AnimateTransformTypeSkewY ->
            "skewY"



-- Just changed "type_" to "type" in function body


updatedAnimateTransformType : AnimateTransformType -> Attribute msg
updatedAnimateTransformType transformType =
    attribute "type" <| animateTransformTypeToString transformType



-- Demonstration


animatedRectangle : Float -> (AnimateTransformType -> Attribute msg) -> Svg msg
animatedRectangle posY animateTransformTypeFunction =
    Svg.rect
        [ x 0
        , y posY
        , height 50
        , width 50
        ]
        [ Svg.animateTransform
            [ attributeName "transform"
            , begin [ TimingOffsetValue "0s" ]
            , dur <| Duration "5s"
            , animateTransformTypeFunction AnimateTransformTypeSkewY
            , from 0
            , to 30
            , repeatCount RepeatIndefinite
            ]
            []
        ]


main =
    Svg.svg [ height 250 ]
        [ animatedRectangle 0 animateTransformType
        , animatedRectangle 70 updatedAnimateTransformType
        ]
```