### PR TITLE
Added the functions from2, from3, to2, to3.

### DIFF
--- a/src/TypedSvg/Attributes.elm
+++ b/src/TypedSvg/Attributes.elm
@@ -1,8 +1,8 @@
 module TypedSvg.Attributes exposing
     ( accelerate, accentHeight, accumulate, additive, alignmentBaseline, allowReorder, alphabetic, amplitude, animateTransformType, animationValues, arabicForm, ascent, attributeName, attributeType, autoReverse, baseProfile, baselineShift, bbox, begin, by, calcMode, capHeight, class, clip, clipPath, clipPathUnits, clipRule, color, colorInterpolation, colorProfile, colorRendering, contentScriptType, contentStyleType, contentType, cursor, cx, cy, d, decelerate, descent, direction, display, dominantBaseline, dur, dx, dy, enableBackground, end, exponent, externalResourcesRequired, fill, fillOpacity, fillRule, filter, fontFamily, fontSize, fontSizeAdjust
-    , fontStretch, fontStyle, fontVariant, fontWeight, format, from, fx, fy, g1, g2, glyphName, glyphOrientationHorizontal, glyphOrientationVertical, glyphRef, gradientTransform, gradientUnits, hanging, height, horizAdvX, horizOriginX, horizOriginY, ideographic, imageRendering, intercept, k, kerning, keySplines, keyTimes, lang, lengthAdjust, letterSpacing, lightingColor, local, markerEnd, markerHeight, markerMid, markerStart, markerUnits, markerWidth, mask, maskContentUnits, maskUnits, max, media
+    , fontStretch, fontStyle, fontVariant, fontWeight, format, from, from2, from3, fx, fy, g1, g2, glyphName, glyphOrientationHorizontal, glyphOrientationVertical, glyphRef, gradientTransform, gradientUnits, hanging, height, horizAdvX, horizOriginX, horizOriginY, ideographic, imageRendering, intercept, k, kerning, keySplines, keyTimes, lang, lengthAdjust, letterSpacing, lightingColor, local, markerEnd, markerHeight, markerMid, markerStart, markerUnits, markerWidth, mask, maskContentUnits, maskUnits, max, media
     , method, min, name, noFill, offset, opacity, orient, orientation, origin, overflow, overlinePosition, overlineThickness, panose1, path, pathLength, patternContentUnits, patternTransform, patternUnits, pointOrder, pointerEvents, points, preserveAspectRatio, primitiveUnits, r, refX, refY, renderingIntent, repeatCount, repeatDur, requiredExtensions, requiredFeatures, restart, rotate, rx, ry, shapeRendering, slope, spacing, specularConstant, specularExponent, speed, spreadMethod, startOffset
-    , stdDeviation, stemh, stemv, stitchTiles, stopColor, stopOpacity, strikethroughPosition, strikethroughThickness, string, stroke, strokeDasharray, strokeDashoffset, strokeLinecap, strokeLinejoin, strokeMiterlimit, strokeOpacity, strokeWidth, style, systemLanguage, tableValues, target, textAnchor, textDecoration, textLength, textRendering, title, to, transform, u1, u2, underlinePosition, underlineThickness, unicode, unicodeBidi, unicodeRange, unitsPerEm, vAlphabetic, vHanging, vIdeographic
+    , stdDeviation, stemh, stemv, stitchTiles, stopColor, stopOpacity, strikethroughPosition, strikethroughThickness, string, stroke, strokeDasharray, strokeDashoffset, strokeLinecap, strokeLinejoin, strokeMiterlimit, strokeOpacity, strokeWidth, style, systemLanguage, tableValues, target, textAnchor, textDecoration, textLength, textRendering, title, to, to2, to3, transform, u1, u2, underlinePosition, underlineThickness, unicode, unicodeBidi, unicodeRange, unitsPerEm, vAlphabetic, vHanging, vIdeographic
     , vMathematical, version, vertAdvY, vertOriginX, vertOriginY, viewBox, viewTarget, visibility, width, widths, wordSpacing, writingMode, x, x1, x2, xChannelSelector, xHeight, xlinkActuate, xlinkArcrole, xlinkHref, xlinkRole, xlinkShow, xlinkTitle, xlinkType, xmlBase, xmlLang, xmlSpace, y, y1, y2, yChannelSelector, zoomAndPan
     )
 
@@ -14,9 +14,9 @@ NOTE: For attributes pertaining to SVG filters, see Filters.Attributes
 # Other attributes
 
 @docs accelerate, accentHeight, accumulate, additive, alignmentBaseline, allowReorder, alphabetic, amplitude, animateTransformType, animationValues, arabicForm, ascent, attributeName, attributeType, autoReverse, baseProfile, baselineShift, bbox, begin, by, calcMode, capHeight, class, clip, clipPath, clipPathUnits, clipRule, color, colorInterpolation, colorProfile, colorRendering, contentScriptType, contentStyleType, contentType, cursor, cx, cy, d, decelerate, descent, direction, display, dominantBaseline, dur, dx, dy, enableBackground, end, exponent, externalResourcesRequired, fill, fillOpacity, fillRule, filter, fontFamily, fontSize, fontSizeAdjust
-@docs fontStretch, fontStyle, fontVariant, fontWeight, format, from, fx, fy, g1, g2, glyphName, glyphOrientationHorizontal, glyphOrientationVertical, glyphRef, gradientTransform, gradientUnits, hanging, height, horizAdvX, horizOriginX, horizOriginY, ideographic, imageRendering, intercept, k, kerning, keySplines, keyTimes, lang, lengthAdjust, letterSpacing, lightingColor, local, markerEnd, markerHeight, markerMid, markerStart, markerUnits, markerWidth, mask, maskContentUnits, maskUnits, max, media
+@docs fontStretch, fontStyle, fontVariant, fontWeight, format, from, from2, from3, fx, fy, g1, g2, glyphName, glyphOrientationHorizontal, glyphOrientationVertical, glyphRef, gradientTransform, gradientUnits, hanging, height, horizAdvX, horizOriginX, horizOriginY, ideographic, imageRendering, intercept, k, kerning, keySplines, keyTimes, lang, lengthAdjust, letterSpacing, lightingColor, local, markerEnd, markerHeight, markerMid, markerStart, markerUnits, markerWidth, mask, maskContentUnits, maskUnits, max, media
 @docs method, min, name, noFill, offset, opacity, orient, orientation, origin, overflow, overlinePosition, overlineThickness, panose1, path, pathLength, patternContentUnits, patternTransform, patternUnits, pointOrder, pointerEvents, points, preserveAspectRatio, primitiveUnits, r, refX, refY, renderingIntent, repeatCount, repeatDur, requiredExtensions, requiredFeatures, restart, rotate, rx, ry, shapeRendering, slope, spacing, specularConstant, specularExponent, speed, spreadMethod, startOffset
-@docs stdDeviation, stemh, stemv, stitchTiles, stopColor, stopOpacity, strikethroughPosition, strikethroughThickness, string, stroke, strokeDasharray, strokeDashoffset, strokeLinecap, strokeLinejoin, strokeMiterlimit, strokeOpacity, strokeWidth, style, systemLanguage, tableValues, target, textAnchor, textDecoration, textLength, textRendering, title, to, transform, u1, u2, underlinePosition, underlineThickness, unicode, unicodeBidi, unicodeRange, unitsPerEm, vAlphabetic, vHanging, vIdeographic
+@docs stdDeviation, stemh, stemv, stitchTiles, stopColor, stopOpacity, strikethroughPosition, strikethroughThickness, string, stroke, strokeDasharray, strokeDashoffset, strokeLinecap, strokeLinejoin, strokeMiterlimit, strokeOpacity, strokeWidth, style, systemLanguage, tableValues, target, textAnchor, textDecoration, textLength, textRendering, title, to, to2, to3, transform, u1, u2, underlinePosition, underlineThickness, unicode, unicodeBidi, unicodeRange, unitsPerEm, vAlphabetic, vHanging, vIdeographic
 @docs vMathematical, version, vertAdvY, vertOriginX, vertOriginY, viewBox, viewTarget, visibility, width, widths, wordSpacing, writingMode, x, x1, x2, xChannelSelector, xHeight, xlinkActuate, xlinkArcrole, xlinkHref, xlinkRole, xlinkShow, xlinkTitle, xlinkType, xmlBase, xmlLang, xmlSpace, y, y1, y2, yChannelSelector, zoomAndPan
 
 -}
@@ -966,6 +966,18 @@ See: <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/from>
 from : Float -> Attribute msg
 from value =
     attribute "from" <| String.fromFloat value
+
+
+{-| -}
+from2 : Float -> Float -> Attribute msg
+from2 a b =
+    attribute "from" <| floatsToString [ a, b ]
+
+
+{-| -}
+from3 : Float -> Float -> Float -> Attribute msg
+from3 a b c =
+    attribute "from" <| floatsToString [ a, b, c ]
 
 
 {-| For the `radialGradient` element, this attribute defines the x-axis
@@ -2039,6 +2051,18 @@ to value =
     attribute "to" <| String.fromFloat value
 
 
+{-| -}
+to2 : Float -> Float -> Attribute msg
+to2 a b =
+    attribute "to" <| floatsToString [ a, b ]
+
+
+{-| -}
+to3 : Float -> Float -> Float -> Attribute msg
+to3 a b c =
+    attribute "to" <| floatsToString [ a, b, c ]
+
+
 {-| The transform attribute defines a list of transform definitions that are
 applied to an element and the element's children. The items in the transform
 list are applied from right to left.
@@ -2431,6 +2455,17 @@ yChannelSelector =
 zoomAndPan : String -> Attribute msg
 zoomAndPan =
     attribute "zoomAndPan"
+
+
+
+-- Helpers - not exposed
+
+
+floatsToString : List Float -> String
+floatsToString floatsList =
+    floatsList
+        |> List.map String.fromFloat
+        |> String.join " "
 
 
 


### PR DESCRIPTION
The functions `to` and `from` can be used to set important attributes for transformation animations. They only take one float value as an argument, which is enough for `skewX` and `skewY`. But `translate` and `scale` can take two floats and `rotate` takes three. Therefore I've added the functions `from2`, `from3`, `to2` and `to3`. I imagine their names are in the spirit of the map functions.

The svg tutorial which got me started on this:
http://tutorials.jenkov.com/svg/svg-animation.html

Here's an ellie with a rotate animation in action:
https://ellie-app.com/3qq59rhvx9za1

Reproducing the ellie code for posterity:
```
module Main exposing (main)

import TypedSvg as Svg
import TypedSvg.Attributes exposing (..)
import TypedSvg.Attributes.InPx exposing (height, width, x, y)
import TypedSvg.Core exposing (Attribute, Svg, attribute)
import TypedSvg.Types exposing (..)



-- Could not import


animateTransformTypeToString : AnimateTransformType -> String
animateTransformTypeToString animateTransformType =
    case animateTransformType of
        AnimateTransformTypeTranslate ->
            "translate"

        AnimateTransformTypeScale ->
            "scale"

        AnimateTransformTypeRotate ->
            "rotate"

        AnimateTransformTypeSkewX ->
            "skewX"

        AnimateTransformTypeSkewY ->
            "skewY"



-- Change from an earlier pull request


updatedAnimateTransformType : AnimateTransformType -> Attribute msg
updatedAnimateTransformType transformType =
    attribute "type" <| animateTransformTypeToString transformType



-- Proposed additions


floatsToString : List Float -> String
floatsToString floatsList =
    floatsList
        |> List.map String.fromFloat
        |> String.join " "


from2 : Float -> Float -> Attribute msg
from2 a b =
    attribute "from" <| floatsToString [ a, b ]


from3 : Float -> Float -> Float -> Attribute msg
from3 a b c =
    attribute "from" <| floatsToString [ a, b, c ]


to2 : Float -> Float -> Attribute msg
to2 a b =
    attribute "to" <| floatsToString [ a, b ]


to3 : Float -> Float -> Float -> Attribute msg
to3 a b c =
    attribute "to" <| floatsToString [ a, b, c ]



-- Demonstration


main =
    Svg.svg []
        [ Svg.rect
            [ x 30
            , y 30
            , height 60
            , width 60
            ]
            [ Svg.animateTransform
                [ attributeName "transform"
                , begin [ TimingOffsetValue "0s" ]
                , dur <| Duration "15s"
                , updatedAnimateTransformType AnimateTransformTypeRotate
                , from3 0 60 60
                , to3 360 60 60
                , repeatCount RepeatIndefinite
                ]
                []
            ]
        ]
```