### PR TITLE
Fixed `in` values.

### DIFF
--- a/src/TypedSvg/TypesToStrings.elm
+++ b/src/TypedSvg/TypesToStrings.elm
@@ -733,19 +733,19 @@ inValueToString : InValue -> String
 inValueToString inValue =
     case inValue of
         InSourceGraphic ->
-            "sourceGraphic"
+            "SourceGraphic"
 
         InSourceAlpha ->
-            "sourceAlpha"
+            "SourceAlpha"
 
         InBackgroundAlpha ->
-            "backgroundAlpha"
+            "BackgroundAlpha"
 
         InFillPaint ->
-            "fillPaint"
+            "FillPaint"
 
         InStrokePaint ->
-            "strokePaint"
+            "StrokePaint"
 
         InReference str ->
             str


### PR DESCRIPTION
`in` values should start from a capital letter.