### PR TITLE
Add doc for the Text section of TypedSvg

### DIFF
--- a/src/TypedSvg.elm
+++ b/src/TypedSvg.elm
@@ -386,7 +386,27 @@ tref =
     node "tref"
 
 
-{-| -}
+{-| The `tspan` element defines a subtext within a `text_` element or
+another `tspan` element. It allows for adjustment of the style and/or
+position of that subtext.
+
+    text_
+        [ x (px 0)
+        , y (px 40)
+        , fontFamily [ "Helvetica", "sans-serif" ]
+        ]
+        [ text "Hello "
+        , tspan
+            [ dy (px 10)
+            , fontFamily [ "Georgia", "serif" ]
+            , fontSize (px 30)
+            , fontWeight FontWeightBold
+            ]
+            [ text "New" ]
+        , text " World"
+        ]
+
+-}
 tspan : List (Attribute msg) -> List (Svg msg) -> Svg msg
 tspan =
     node "tspan"

--- a/src/TypedSvg.elm
+++ b/src/TypedSvg.elm
@@ -324,7 +324,32 @@ glyphRef =
     node "glyphRef"
 
 
-{-| -}
+{-| The `textPath` element draws text along the shape of a path.
+It is usually embedded within a `text_` element.
+
+    import TypedSvg exposing (..)
+    import TypedSvg.Attributes exposing (..)
+    import TypedSvg.Core exposing (text, attribute)
+    import TypedSvg.Types exposing (px, Paint(..))
+
+    svg
+        [ width (px 100), height (px 100), viewBox 0 0 100 100 ]
+        [ TypedSvg.path
+            [ id "MyPath"
+            , fill PaintNone
+            , stroke (Paint Color.red)
+            , d "M10,90 Q90,90 90,45 Q90,10 50,10 Q10,10 10,40 Q10,70 45,70 Q70,70 75,50"
+            ]
+            []
+        , text_
+            []
+            [ textPath
+                [ attribute "href" "#MyPath" ]
+                [ text "Quick brown fox jumps over the lazy dog." ]
+            ]
+        ]
+
+-}
 textPath : List (Attribute msg) -> List (Svg msg) -> Svg msg
 textPath =
     node "textPath"

--- a/src/TypedSvg.elm
+++ b/src/TypedSvg.elm
@@ -330,7 +330,26 @@ textPath =
     node "textPath"
 
 
-{-| -}
+{-| The `text_` element draws a graphics element consisting of text.
+It should not be confused with `text` in `TypedSvg.Core` which produces
+a simple text node without any tags. `text` is often embedded within `text_`
+to specify its content.
+
+    import TypedSvg exposing (..)
+    import TypedSvg.Core exposing (text)
+    import TypedSvg.Attributes exposing (..)
+    import TypedSvg.Types exposing (px, FontWeight(..))
+
+    text_
+        [ x (px 20)
+        , y (px 35)
+        , fontFamily [ "Helvetica", "sans-serif" ]
+        , fontSize (px 30)
+        , fontWeight FontWeightBold
+        ]
+        [ text "Hello World" ]
+
+-}
 text_ : List (Attribute msg) -> List (Svg msg) -> Svg msg
 text_ =
     node "text"


### PR DESCRIPTION
## What I did
I added explainations and examples for `text_`, `textPath_`, and `tspan`.
To verify that the example codes work, I created a demo in Ellie-app for each.
* [text_](https://ellie-app.com/bPnrrXFc9Dza1)
* [textPath](https://ellie-app.com/bPnnmGqtJRwa1)
* [tspan](https://ellie-app.com/bPnB4S2zdHHa1)

## Questions
I'm not sure whether to include the imports for `text_` and `textPath`. For the `text_`, it uses `TypedSvg.Core.text` which I feel needs the import to clarify. For the `textPath`, it uses a rather uncommon `TypedSvg.Core.attribute` (`href` is not supported currently) which compells me to include the imports. I don't know much about the documentation convention of this project, so feel free to correct me.