### PR TITLE
Add support for CSS variables in `fill` and `stroke`

### DIFF
--- a/src/Examples/Paints.elm
+++ b/src/Examples/Paints.elm
@@ -1,0 +1,52 @@
+module Examples.Paints exposing (main)
+
+import Color
+import Html exposing (Html, div, node)
+import TypedSvg exposing (circle, g, pattern, rect, svg, text_)
+import TypedSvg.Attributes exposing (cx, cy, fill, id, patternUnits, r, stroke, strokeWidth, textAnchor, transform, viewBox)
+import TypedSvg.Attributes.InPx exposing (fontSize, height, width, x, y)
+import TypedSvg.Core exposing (Svg, text)
+import TypedSvg.Types exposing (AnchorAlignment(..), CoordinateSystem(..), Paint(..), Transform(..), px)
+
+
+drawCircle : Paint -> Float -> String -> Svg msg
+drawCircle paint left label =
+    g
+        [ transform [ Translate left 60 ] ]
+        [ circle
+            [ cx (px 30)
+            , cy (px 0)
+            , r (px 30)
+            , fill paint
+            , stroke <| Paint Color.grey
+            ]
+            []
+        , text_ [ x 30, y 40, textAnchor AnchorMiddle ] [ text label ]
+        ]
+
+
+main : Html msg
+main =
+    div []
+        [ node "style" [] [ text """
+        :root {--custom-pink: #f0bbd1;}
+        svg {font-family: monospace; font-size: 5px;}
+        """ ]
+        , svg [ viewBox 0 0 800 600 ]
+            [ pattern
+                [ id "chessPattern"
+                , width 50
+                , height 50
+                , patternUnits CoordinateSystemUserSpaceOnUse
+                ]
+                [ rect [ x 0, y 0, width 25, height 25, fill <| Paint <| Color.rgb255 184 0 0 ] []
+                , rect [ x 25, y 0, width 25, height 25, fill <| Paint <| Color.rgb255 25 25 25 ] []
+                , rect [ x 0, y 25, width 25, height 25, fill <| Paint <| Color.rgb255 25 25 25 ] []
+                , rect [ x 25, y 25, width 25, height 25, fill <| Paint <| Color.rgb255 184 0 0 ] []
+                ]
+            , drawCircle (Paint Color.red) 10 "Paint Color.red"
+            , drawCircle (CSSVariable "--custom-pink") 90 "CSSVariable \"--custom-pink\""
+            , drawCircle (Reference "chessPattern") 170 "Reference \"chessPattern\""
+            , drawCircle PaintNone 250 "PaintNone"
+            ]
+        ]

--- a/src/TypedSvg/Types.elm
+++ b/src/TypedSvg/Types.elm
@@ -471,14 +471,15 @@ type Opacity
     | OpacityInherit
 
 
-{-| fill, color and stroke accepted values
+{-| `fill` and `stroke` accepted values
 
-    fill <| Paint Color.red      == `fill="#FF0000"`
-    fill <| CSSVariable "--text" == `fill="var(--text)"`
-    fill <| Reference "some-id"  == `fill="url(#some-id)"`
-    fill <| ContextFill          == `fill="context-fill"`
-    fill <| ContextStroke        == `fill="context-stroke"`
-    fill <| PaintNone            == `fill="none"`
+    [ fill <| Paint Color.red --      fill="#FF0000"
+    , fill <| CSSVariable "--text" -- fill="var(--text)"
+    , fill <| Reference "some-id" --  fill="url(#some-id)"
+    , fill <| ContextFill --          fill="context-fill"
+    , fill <| ContextStroke --        fill="context-stroke"
+    , fill <| PaintNone --            fill="none"
+    ]
 
 -}
 type Paint

--- a/src/TypedSvg/Types.elm
+++ b/src/TypedSvg/Types.elm
@@ -474,6 +474,7 @@ type Opacity
 {-| -}
 type Paint
     = Paint Color
+    | CSSVariable String
     | Reference String
     | ContextFill
     | ContextStroke

--- a/src/TypedSvg/Types.elm
+++ b/src/TypedSvg/Types.elm
@@ -471,7 +471,16 @@ type Opacity
     | OpacityInherit
 
 
-{-| -}
+{-| fill, color and stroke accepted values
+
+    fill <| Paint Color.red      == `fill="#FF0000"`
+    fill <| CSSVariable "--text" == `fill="var(--text)"`
+    fill <| Reference "some-id"  == `fill="url(#some-id)"`
+    fill <| ContextFill          == `fill="context-fill"`
+    fill <| ContextStroke        == `fill="context-stroke"`
+    fill <| PaintNone            == `fill="none"`
+
+-}
 type Paint
     = Paint Color
     | CSSVariable String

--- a/src/TypedSvg/TypesToStrings.elm
+++ b/src/TypedSvg/TypesToStrings.elm
@@ -13,11 +13,11 @@ module TypedSvg.TypesToStrings exposing
     , fontVariantToString, fontWeightToString, funcTypeToString, inValueToString
     , kerningToString, lengthAdjustToString, lengthToString
     , markerCoordinateSystemToString, meetOrSliceToString, modeToString
-    , morphologyOperatorToString, opacityToString, paintToString
+    , morphologyOperatorToString, opacityToString
     , renderingToString, repeatCountToString, restartToString, scaleToString
     , shapeRenderingToString, timingValueAsString, transformToString
     , turbulenceTypeToString, yesNoToString
-    , strokeLinecapToString, strokeLinejoinToString, textRenderingToString
+    , paintToString, strokeLinecapToString, strokeLinejoinToString, textRenderingToString
     )
 
 {-|
@@ -863,16 +863,21 @@ paintToString paint =
         Paint color ->
             toCssString color
 
+        CSSVariable string ->
+            String.concat [ "var(" ++ string ++ ")" ]
+
         Reference string ->
-            String.concat ["url(#", string,")"]
+            String.concat [ "url(#", string, ")" ]
 
         ContextFill ->
             "context-fill"
 
         ContextStroke ->
             "context-stroke"
+
         PaintNone ->
             "none"
+
 
 renderingToString : Rendering -> String
 renderingToString rendering =


### PR DESCRIPTION
I added support for css variables in fill and stroke. They should be applied everywhere, but this is the use case I faced and also the one mentioned in this issue:

https://github.com/elm-community/typed-svg/issues/39